### PR TITLE
feat: Disable NotificationPermission check from Lint since the app do…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,10 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    lintOptions {
+        disable("NotificationPermission")
+    }
+
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
…esn't have a notification feature.

The glide library's last version internally references notification functionality (NotificationTarget), and it makes the ci fail in the Lint step.